### PR TITLE
Fix IDT limit

### DIFF
--- a/kernel/interrupts.c
+++ b/kernel/interrupts.c
@@ -87,7 +87,7 @@ void interrupt_init() {
 
     interrupt_new_handler(0x21, keyboard_handler);
 
-    uint16_t size = (sizeof(idt_entry) * 256);
+    uint16_t size = (sizeof(idt_entry) * 256) - 1;
 
     lidt(IDT, size);
 


### PR DESCRIPTION
According to Intel manual Volume 3: 6.10 INTERRUPT DESCRIPTOR TABLE (IDT)
> Because IDT entries are always eight bytes long, the limit should
always be one less than an integral multiple of eight (that is, 8N – 1).